### PR TITLE
Let users select date ranges throughout the ski season

### DIFF
--- a/app/views/reservations/_form.html.erb
+++ b/app/views/reservations/_form.html.erb
@@ -72,23 +72,17 @@
   </div>
 <% end %>
 <script type="text/javascript">
-var a = moment().day("Wednessday").week(Number).format('MMMM D, YYYY').toString() + ' - ' + moment().day("Wednessday").week(Number).add('days', 6).format('MMMM D, YYYY').toString();
-var b = moment().day("Wednessday").week(Number).add('days', 7).format('MMMM D, YYYY').toString() + ' - ' + moment().day("Wednessday").week(Number).add('days', 13).format('MMMM D, YYYY').toString();
-var c = moment().day("Wednessday").week(Number).add('days', 14).format('MMMM D, YYYY').toString() + ' - ' + moment().day("Wednessday").week(Number).add('days', 20).format('MMMM D, YYYY').toString();
-var d = moment().day("Wednessday").week(Number).add('days',21 ).format('MMMM D, YYYY').toString() + ' - ' + moment().day("Wednessday").week(Number).add('days', 27).format('MMMM D, YYYY').toString();
-var e = moment().day("Wednessday").week(Number).add('days',28 ).format('MMMM D, YYYY').toString() + ' - ' + moment().day("Wednessday").week(Number).add('days', 34).format('MMMM D, YYYY').toString();
-var f = moment().day("Wednessday").week(Number).add('days', 35 ).format('MMMM D, YYYY').toString() + ' - ' + moment().day("Wednessday").week(Number).add('days', 41).format('MMMM D, YYYY').toString();
-var g = moment().day("Wednessday").week(Number).add('days', 42 ).format('MMMM D, YYYY').toString() + ' - ' + moment().day("Wednessday").week(Number).add('days', 48).format('MMMM D, YYYY').toString();
-var h = moment().day("Wednessday").week(Number).add('days', 49 ).format('MMMM D, YYYY').toString() + ' - ' + moment().day("Wednessday").week(Number).add('days', 55).format('MMMM D, YYYY').toString();
+//set how many weeks out we allow users to scheudle
+const WEEKS_OUT = 25
 var obj = {};
-obj[a] = [moment().day("Wednessday").week(Number), moment().day("Wednessday").week(Number).add('days', 6)];
-obj[b] = [moment().day("Wednessday").week(Number).add('days', 7), moment().day("Wednessday").week(Number).add('days', 13)];
-obj[c] = [moment().day("Wednessday").week(Number).add('days', 14), moment().day("Wednessday").week(Number).add('days', 20)];
-obj[d] = [moment().day("Wednessday").week(Number).add('days',21 ), moment().day("Wednessday").week(Number).add('days', 27)];
-obj[e] = [moment().day("Wednessday").week(Number).add('days',28 ), moment().day("Wednessday").week(Number).add('days', 34)];
-obj[f] = [moment().day("Wednessday").week(Number).add('days', 35 ), moment().day("Wednessday").week(Number).add('days', 41)];
-obj[g] = [moment().day("Wednessday").week(Number).add('days', 42 ), moment().day("Wednessday").week(Number).add('days', 48)];
-obj[h] = [moment().day("Wednessday").week(Number).add('days', 49 ), moment().day("Wednessday").week(Number).add('days', 55)];
+
+for (var i = 0; i < WEEKS_OUT; i++) {
+  var dayOne = moment().day("Wednesday").week(Number).add('days', i*7)
+  var dayTwo = moment().day("Wednesday").week(Number).add('days', i*7+6)
+  var label = dayOne.format('MMMM D, YYYY').toString() + ' - ' + dayTwo.format('MMMM D, YYYY').toString()
+  obj[label] = [dayOne, dayTwo]
+}
+
 $('#reportrange').daterangepicker(
     {
       ranges: obj,
@@ -100,5 +94,8 @@ $('#reportrange').daterangepicker(
         $('#reservation_reservation_date').val(start.format('"YYYY/MM/DD"'));
     }
 );
+//hack to hide calendar since i need to move on
+$('.drp-calendar').css("display","none");
+
 </script>
 


### PR DESCRIPTION
This PR DRYs up the calendar code, and extends the available date ranges through the ski season as Tommy requested.